### PR TITLE
Add non-illusionist gnome mages component

### DIFF
--- a/gemrb-tweaks/gemrb-tweaks.tp2
+++ b/gemrb-tweaks/gemrb-tweaks.tp2
@@ -51,3 +51,13 @@ ACTION_FOR_EACH ini IN array BEGIN
   END
 END
 */
+
+BEGIN @500 DESIGNATED 500 // Don't restrict gnomes to Illusionist kit
+REQUIRE_PREDICATE GAME_IS ~bg1 totsc bg2 tob iwd how totlm~ @501
+  COPY_EXISTING ~classes.2da~ ~override~
+  SET_2DA_ENTRY 6 15 15 ~1~
+  SET_2DA_ENTRY 11 15 15 ~1~
+  SET_2DA_ENTRY 12 15 15 ~1~
+  SET_2DA_ENTRY 13 15 15 ~1~
+  SET_2DA_ENTRY 17 15 15 ~1~
+  SET_2DA_ENTRY 18 15 15 ~1~

--- a/gemrb-tweaks/lang/en_US/setup.tra
+++ b/gemrb-tweaks/lang/en_US/setup.tra
@@ -8,3 +8,5 @@
 @300 = ~Maximum hitpoints per level~
 @301 = ~This component is not relevant for games other than BG1~
 @400 = ~TobEx-like concetration checks~
+@500 = ~Do not restrict Gnome mages to the Illusionist school~
+@501 = ~This component is only relevant for IWD1, BG1 and BG2~


### PR DESCRIPTION
Component changes the values in the Gnome column of classes.2da for any mage classes from 2 to 1. Affects IWD1, BG1&2 installations. Tested on my local game installations. Path to GemRB installation must be passed to weidu or classes.2da has to be present in game override folder for it to work.